### PR TITLE
mac GL version restored, GL ver bugfixes

### DIFF
--- a/cocos2d/cocos/renderer/CCCustomCommand.cpp
+++ b/cocos2d/cocos/renderer/CCCustomCommand.cpp
@@ -91,8 +91,10 @@ void CustomCommand::createIndexBuffer(IndexFormat format, unsigned int capacity,
 void CustomCommand::updateVertexBuffer(void* data, unsigned int offset, unsigned int length)
 {   
     assert(_vertexBuffer);
-    if (!_vertexBuffer->isAllocated())
+    if (!_vertexBuffer->isAllocated()){
+        assert(offset == 0);
         _vertexBuffer->updateData(data, length);
+    }
     else
         _vertexBuffer->updateSubData(data, offset, length);
 }
@@ -100,8 +102,10 @@ void CustomCommand::updateVertexBuffer(void* data, unsigned int offset, unsigned
 void CustomCommand::updateIndexBuffer(void* data, unsigned int offset, unsigned int length)
 {
     assert(_indexBuffer);
-    if (!_indexBuffer->isAllocated())
+    if (!_indexBuffer->isAllocated()){
+        assert(offset == 0);
         _indexBuffer->updateData(data, length);
+    }
     else
         _indexBuffer->updateSubData(data, offset, length);
 }

--- a/cocos2d/cocos/renderer/backend/metal/DeviceMTL.mm
+++ b/cocos2d/cocos/renderer/backend/metal/DeviceMTL.mm
@@ -40,6 +40,7 @@ CC_BACKEND_BEGIN
 CAMetalLayer* DeviceMTL::_metalLayer = nil;
 id<CAMetalDrawable> DeviceMTL::_currentDrawable = nil;
 
+#ifdef CC_USE_METAL
 Device* Device::getInstance()
 {
     if (! Device::_instance)
@@ -47,6 +48,7 @@ Device* Device::getInstance()
 
     return Device::_instance;
 }
+#endif
 
 void DeviceMTL::setCAMetalLayer(CAMetalLayer* metalLayer)
 {

--- a/cocos2d/cocos/renderer/backend/opengl/CommandBufferGL.cpp
+++ b/cocos2d/cocos/renderer/backend/opengl/CommandBufferGL.cpp
@@ -249,7 +249,11 @@ void CommandBufferGL::applyRenderPassDescriptor(const RenderPassDescriptor& desc
         glGetIntegerv(GL_DEPTH_FUNC, &oldDepthFunc);
         
         mask |= GL_DEPTH_BUFFER_BIT;
+#ifdef CC_USE_GL
+        glClearDepth(descirptor.clearDepthValue);
+#else
         glClearDepthf(descirptor.clearDepthValue);
+#endif
         glEnable(GL_DEPTH_TEST);
         glDepthMask(GL_TRUE);
         glDepthFunc(GL_ALWAYS);
@@ -275,7 +279,11 @@ void CommandBufferGL::applyRenderPassDescriptor(const RenderPassDescriptor& desc
         
         glDepthMask(oldDepthWrite);
         glDepthFunc(oldDepthFunc);
-        glClearDepthf(oldDepthClearValue);
+        #ifdef CC_USE_GL
+                glClearDepth(oldDepthClearValue);
+        #else
+                glClearDepthf(oldDepthClearValue);
+        #endif
     }
     
     CHECK_GL_ERROR_DEBUG();
@@ -350,6 +358,9 @@ void CommandBufferGL::drawArrays(PrimitiveType primitiveType, unsigned int start
 
 void CommandBufferGL::drawElements(PrimitiveType primitiveType, IndexFormat indexType, unsigned int count, unsigned int offset)
 {
+    if( count <= 0 )
+        return;
+    
     prepareDrawing();
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, _indexBuffer->getHandler());
     glDrawElements(UtilsGL::toGLPrimitiveType(primitiveType), count, UtilsGL::toGLIndexType(indexType), reinterpret_cast<GLvoid*>(offset));
@@ -441,6 +452,7 @@ void CommandBufferGL::unbindVertexBuffer(ProgramGL *program) const
         return;
     
     glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 
     const auto& attributes = vertexLayout->getAttributes();
     for (const auto& attributeInfo : attributes)

--- a/cocos2d/cocos/renderer/backend/opengl/CommandBufferGL.cpp
+++ b/cocos2d/cocos/renderer/backend/opengl/CommandBufferGL.cpp
@@ -431,6 +431,25 @@ void CommandBufferGL::bindVertexBuffer(ProgramGL *program) const
     }
 }
 
+void CommandBufferGL::unbindVertexBuffer(ProgramGL *program) const
+{
+    // Bind vertex buffers and set the attributes.
+    auto vertexLayout = _programState->getVertexLayout();
+    
+    if (!vertexLayout->isValid() ||
+        !_vertexBuffer)
+        return;
+    
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+    const auto& attributes = vertexLayout->getAttributes();
+    for (const auto& attributeInfo : attributes)
+    {
+        const auto& attribute = attributeInfo.second;
+        glDisableVertexAttribArray(attribute.index);
+    }
+}
+
 void CommandBufferGL::setUniforms(ProgramGL* program) const
 {
     if (_programState)
@@ -579,6 +598,9 @@ void CommandBufferGL::setUniform(bool isArray, GLuint location, unsigned int siz
 
 void CommandBufferGL::cleanResources()
 {
+    const auto& program = _renderPipeline->getProgram();
+    unbindVertexBuffer(program);
+    
     CC_SAFE_RELEASE_NULL(_indexBuffer);
     CC_SAFE_RELEASE_NULL(_programState);  
     CC_SAFE_RELEASE_NULL(_vertexBuffer);

--- a/cocos2d/cocos/renderer/backend/opengl/CommandBufferGL.cpp
+++ b/cocos2d/cocos/renderer/backend/opengl/CommandBufferGL.cpp
@@ -226,6 +226,16 @@ void CommandBufferGL::applyRenderPassDescriptor(const RenderPassDescriptor& desc
     }
     CHECK_GL_ERROR_DEBUG();
     
+    // set viewport and scissor in order to clear correctly
+    if( descirptor.colorAttachmentsTexture[0] ) {
+        auto texture = dynamic_cast<Texture2DBackend *>(descirptor.colorAttachmentsTexture[0]);
+        if( texture ) {
+            setViewport(0, 0, (unsigned int) texture->getWidth(),
+                        (unsigned int) texture->getHeight());
+            setScissorRect(false, 0, 0, 0, 0);
+        }
+    }
+    
     // set clear color, depth and stencil
     GLbitfield mask = 0;
     if (descirptor.needClearColor)

--- a/cocos2d/cocos/renderer/backend/opengl/CommandBufferGL.h
+++ b/cocos2d/cocos/renderer/backend/opengl/CommandBufferGL.h
@@ -182,6 +182,7 @@ private:
     
     void prepareDrawing() const;
     void bindVertexBuffer(ProgramGL* program) const;
+    void unbindVertexBuffer(ProgramGL* program) const;
     void setUniforms(ProgramGL* program) const;
     void setUniform(bool isArray, GLuint location, unsigned int size, GLenum uniformType, void* data) const;
     void cleanResources();


### PR DESCRIPTION
- Restored GL version on macOS (for debugging purposes, default remains metal ver)
- Fixed missing unbinding of vertex attribs after draw calls