### PR TITLE
Bugfix: Fixed wrong viewport in rendertexture

### DIFF
--- a/cocos2d/cocos/renderer/backend/metal/CommandBufferMTL.h
+++ b/cocos2d/cocos/renderer/backend/metal/CommandBufferMTL.h
@@ -194,6 +194,7 @@ private:
     
     unsigned int _renderTargetWidth = 0;
     unsigned int _renderTargetHeight = 0;
+    unsigned int _renderTargetColorHeight = 0;
     
     dispatch_semaphore_t _frameBoundarySemaphore;
     RenderPassDescriptor _prevRenderPassDescriptor;

--- a/cocos2d/cocos/renderer/backend/metal/CommandBufferMTL.mm
+++ b/cocos2d/cocos/renderer/backend/metal/CommandBufferMTL.mm
@@ -170,6 +170,7 @@ void CommandBufferMTL::beginRenderPass(const RenderPassDescriptor& descriptor)
     auto mtlDescriptor = rc.renderPassDecriptor;
     _renderTargetWidth = (unsigned int)mtlDescriptor.colorAttachments[0].texture.width;
     _renderTargetHeight = (unsigned int)mtlDescriptor.colorAttachments[0].texture.height;
+    _renderTargetColorHeight = (unsigned int)mtlDescriptor.colorAttachments[0].texture.height;
     if (mtlDescriptor.stencilAttachment &&
         mtlDescriptor.stencilAttachment.texture) {
         _renderTargetWidth = std::min(_renderTargetWidth,
@@ -194,7 +195,7 @@ void CommandBufferMTL::setViewport(int x, int y, unsigned int w, unsigned int h)
 {
     MTLViewport viewport;
     viewport.originX = x;
-    viewport.originY = (int)(_renderTargetHeight - y - h);
+    viewport.originY = (int)(_renderTargetColorHeight - y - h);
     viewport.width = w;
     viewport.height = h;
     viewport.znear = -1;


### PR DESCRIPTION
- When the color attachment target's size is different than the stencil/depth's, the viewport y was calculated using the wrong height.
- Fixes weird shifts when using render texture filters combined with clipping node.