### PR TITLE
GL performance: optimise gl command calls

### DIFF
--- a/cocos2d/cocos/2d/CCLayer.cpp
+++ b/cocos2d/cocos/2d/CCLayer.cpp
@@ -455,16 +455,20 @@ void LayerColor::draw(Renderer *renderer, const Mat4 &transform, uint32_t flags)
     cocos2d::Mat4 projectionMat = Director::getInstance()->getMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_PROJECTION);
     auto& pipelineDescriptor = _customCommand.getPipelineDescriptor();
     pipelineDescriptor.programState->setUniform(_mvpMatrixLocation, projectionMat.m, sizeof(projectionMat.m));
-    
-    for(int i = 0; i < 4; ++i)
-    {
-        Vec4 pos;
-        pos.x = _squareVertices[i].x; pos.y = _squareVertices[i].y; pos.z = _positionZ;
-        pos.w = 1;
-        _modelViewTransform.transformVector(pos);
-        _vertexData[i].vertices = Vec4(pos.x/pos.w,pos.y/pos.w,pos.z/pos.w, 1.0f);
+
+    if( _buffersDirty ) {
+        for (int i = 0; i < 4; ++i) {
+            Vec4 pos;
+            pos.x = _squareVertices[i].x;
+            pos.y = _squareVertices[i].y;
+            pos.z = _positionZ;
+            pos.w = 1;
+            _modelViewTransform.transformVector(pos);
+            _vertexData[i].vertices = Vec4(pos.x / pos.w, pos.y / pos.w, pos.z / pos.w, 1.0f);
+        }
+        updateVertexBuffer();
+        _buffersDirty = false;
     }
-    updateVertexBuffer();
 }
 
 void LayerColor::updateVertexBuffer()

--- a/cocos2d/cocos/2d/CCLayer.h
+++ b/cocos2d/cocos/2d/CCLayer.h
@@ -180,6 +180,7 @@ protected:
 
     Touch::DispatchMode _touchMode;
     bool _swallowsTouches;
+    bool _buffersDirty = true;
 
 private:
     CC_DISALLOW_COPY_AND_ASSIGN(Layer)

--- a/cocos2d/cocos/renderer/backend/opengl/BufferGL.cpp
+++ b/cocos2d/cocos/renderer/backend/opengl/BufferGL.cpp
@@ -137,6 +137,8 @@ void BufferGL::updateData(void* data, unsigned long size)
 
 void BufferGL::updateSubData(void* data, unsigned long offset, unsigned long size)
 {
+    if( size == 0 )
+        return;
 
     CCASSERT(_bufferAllocated != 0, "updateData should be invoke before updateSubData");
     CCASSERT(offset + size <= _size, "buffer size overflow");

--- a/cocos2d/cocos/renderer/backend/opengl/CommandBufferGL.h
+++ b/cocos2d/cocos/renderer/backend/opengl/CommandBufferGL.h
@@ -171,6 +171,22 @@ public:
      */
     virtual void captureScreen(std::function<void(const unsigned char*, int, int)> callback) override ;
 
+
+    void setDepthTest(bool enabled);
+    void setDepthMask(uint8_t enabled);
+    void setDepthFunc(CompareFunction function);
+    void setStencilTest(bool enabled);
+    void setDepthClearValue(float value);
+
+    void setStencilFunc(CompareFunction f, float ref, uint8_t mask);
+    void setStencilOp(StencilOperation fail, StencilOperation zfail, StencilOperation zpass);
+    void setStencilMask(uint8_t enabled);
+
+    void setStencilFuncSeparate(CompareFunction backF, float backRef, uint8_t backMask,
+                                CompareFunction frontF, float frontRef, uint8_t frontMask);
+    void setStencilOpSeparate(StencilOperation backFail, StencilOperation backZfail, StencilOperation backZpass,
+                              StencilOperation frontFail, StencilOperation frontZfail, StencilOperation frontZpass);
+    void setStencilMaskSeparate(uint8_t back, uint8_t front);
 private:
     struct Viewport
     {
@@ -180,7 +196,7 @@ private:
         unsigned int h = 0;
     };
     
-    void prepareDrawing() const;
+    void prepareDrawing();
     void bindVertexBuffer(ProgramGL* program) const;
     void unbindVertexBuffer(ProgramGL* program) const;
     void setUniforms(ProgramGL* program) const;
@@ -201,8 +217,48 @@ private:
     BufferGL* _indexBuffer = nullptr;
     RenderPipelineGL* _renderPipeline = nullptr;
     CullMode _cullMode = CullMode::NONE;
+    bool _updateCullMode = true;
+    Winding _winding = (Winding)-1;
     DepthStencilStateGL* _depthStencilStateGL = nullptr;
     Viewport _viewPort;
+    bool _updateStencilState = true;
+    bool _scissorTest = false;
+    float _scissorTestX = -1;
+    float _scissorTestY = -1;
+    float _scissorTestW = -1;
+    float _scissorTestH = -1;
+    float _lineWidth = -1;
+    RenderPassDescriptor _passDescriptor;
+
+    bool _depthTest = false;
+    uint8_t _depthMask = 0;
+    CompareFunction _depthFunction = CompareFunction::LESS_EQUAL;
+    bool _stencilTest = false;
+    float _depthClearValue = 1;
+
+    CompareFunction _stencilFunction = (CompareFunction)-1;
+    float _stencilFunctionRef = -1;
+    uint8_t _stencilFunctionReadMask = -1;
+    StencilOperation _stencilOpFail = (StencilOperation)-1;
+    StencilOperation _stencilOpZFail = (StencilOperation)-1;
+    StencilOperation _stencilOpZPass = (StencilOperation)-1;
+    uint8_t _stencilMask = -1;
+
+    CompareFunction _stencilFunctionBack = (CompareFunction)-1;
+    CompareFunction _stencilFunctionFront = (CompareFunction)-1;
+    float _stencilFunctionRefBack = -1;
+    float _stencilFunctionRefFront = -1;
+    uint8_t _stencilFunctionReadMaskBack = -1;
+    uint8_t _stencilFunctionReadMaskFront = -1;
+    StencilOperation _stencilOpFailBack = (StencilOperation)-1;
+    StencilOperation _stencilOpZFailBack = (StencilOperation)-1;
+    StencilOperation _stencilOpZPassBack = (StencilOperation)-1;
+    StencilOperation _stencilOpFailFront = (StencilOperation)-1;
+    StencilOperation _stencilOpZFailFront = (StencilOperation)-1;
+    StencilOperation _stencilOpZPassFront = (StencilOperation)-1;
+    uint8_t _stencilMaskBack = -1;
+    uint8_t _stencilMaskFront = -1;
+
 
 #if CC_ENABLE_CACHE_TEXTURE_DATA
     EventListenerCustom* _backToForegroundListener = nullptr;

--- a/cocos2d/cocos/renderer/backend/opengl/DepthStencilStateGL.h
+++ b/cocos2d/cocos/renderer/backend/opengl/DepthStencilStateGL.h
@@ -34,14 +34,14 @@ CC_BACKEND_BEGIN
  * @{
  */
 
+class CommandBufferGL;
+
 /**
  * Set depth and stencil status to pipeline.
  */
 class DepthStencilStateGL : public DepthStencilState
 {
 public:
-    /// Reset to default state.
-    static void reset();
     
     /**
      * @param descriptor Specifies the depth and stencil status.
@@ -53,7 +53,8 @@ public:
      * @param stencilReferenceValueFront Specifies front stencil reference value.
      * @param stencilReferenceValueBack Specifies back stencil reference value.
      */
-    void apply(unsigned int stencilReferenceValueFront, unsigned int stencilReferenceValueBack) const;
+    void apply(unsigned int stencilReferenceValueFront, unsigned int stencilReferenceValueBack, CommandBufferGL* gl) const;
+
 };
 //end of _opengl group
 /// @}

--- a/cocos2d/cocos/renderer/backend/opengl/RenderPipelineGL.cpp
+++ b/cocos2d/cocos/renderer/backend/opengl/RenderPipelineGL.cpp
@@ -48,6 +48,17 @@ void RenderPipelineGL::update(const PipelineDescriptor& pipelineDescirptor, cons
 
 void RenderPipelineGL::updateBlendState(const BlendDescriptor& descriptor)
 {
+    if( descriptor.blendEnabled == _blendState.blendEnabled &&
+    descriptor.alphaBlendOperation == _blendState.alphaBlendOperation &&
+    descriptor.sourceRGBBlendFactor == _blendState.sourceRGBBlendFactor &&
+    descriptor.destinationRGBBlendFactor == _blendState.destinationRGBBlendFactor &&
+    descriptor.sourceAlphaBlendFactor == _blendState.sourceAlphaBlendFactor &&
+    descriptor.destinationAlphaBlendFactor == _blendState.destinationAlphaBlendFactor &&
+    descriptor.writeMask == _blendState.writeMask)
+        return;
+
+    _blendState = descriptor;
+
     auto blendEnabled = descriptor.blendEnabled;
     auto rgbBlendOperation = UtilsGL::toGLBlendOperation(descriptor.rgbBlendOperation);
     auto alphaBlendOperation = UtilsGL::toGLBlendOperation(descriptor.alphaBlendOperation);

--- a/cocos2d/cocos/renderer/backend/opengl/RenderPipelineGL.h
+++ b/cocos2d/cocos/renderer/backend/opengl/RenderPipelineGL.h
@@ -64,6 +64,7 @@ private:
     void updateBlendState(const BlendDescriptor& descriptor);
 
     ProgramGL* _programGL = nullptr;
+    BlendDescriptor _blendState;
 };
 // end of _opengl group
 /// @}


### PR DESCRIPTION
- State of each relevant gl commands (such as depth/stencil test etc) store in memory to avoid issuing a gl command every time